### PR TITLE
fix(useSriManifest): avoid unhandled AbortError from CORS probe

### DIFF
--- a/components/src/__tests__/useSriManifest.test.ts
+++ b/components/src/__tests__/useSriManifest.test.ts
@@ -97,6 +97,41 @@ describe('useSriManifest', () => {
     expect(result.current.sri).toBe(mockManifest.scripts['instnt_v1.js'].sri);
   });
 
+  it('does not produce an unhandled rejection when unmounted before manifest resolves', async () => {
+    // Regression test: previously `scriptCorsprobe` was created eagerly in
+    // parallel with `manifestFetch` sharing the same AbortController. When the
+    // effect cleanup fired before the manifest resolved (e.g. React 18
+    // StrictMode's simulated unmount in dev), the probe's AbortError had no
+    // handler attached and bubbled up as an uncaught promise rejection.
+    const unhandled: unknown[] = [];
+    const onUnhandled = (e: PromiseRejectionEvent) => {
+      unhandled.push(e.reason);
+      e.preventDefault();
+    };
+    window.addEventListener('unhandledrejection', onUnhandled);
+
+    // Never-resolving fetches so the cleanup races with resolution
+    (window.fetch as jest.Mock).mockImplementation((_url: string, init?: RequestInit) => {
+      return new Promise((_resolve, reject) => {
+        init?.signal?.addEventListener('abort', () => {
+          reject(new DOMException('The operation was aborted.', 'AbortError'));
+        });
+      });
+    });
+
+    const { unmount } = renderHook(() => useSriManifest('sandbox2-never-resolves'));
+
+    unmount();
+
+    // Let any microtask-queued rejections flush
+    await flushPromises();
+    await flushPromises();
+
+    window.removeEventListener('unhandledrejection', onUnhandled);
+
+    expect(unhandled).toEqual([]);
+  });
+
   it('handles manifest fetch failure', async () => {
     (window.fetch as jest.Mock).mockImplementation(() => {
       return Promise.resolve({

--- a/components/src/hooks/useSriManifest.ts
+++ b/components/src/hooks/useSriManifest.ts
@@ -61,13 +61,7 @@ const useSriManifest = (environment: string): UseSriManifestResult => {
       headers: { Accept: 'application/json' },
       signal: controller.signal,
     })
-    
-    const scriptCorsprobe = fetch(scriptUrl, {
-      method: 'HEAD',
-      mode: 'cors',
-      signal: controller.signal,
-    });
-    
+
     manifestFetch.then((res) => {
       if (!res.ok) throw new Error(`HTTP ${res.status} from ${manifestUrl}`);
       return res.json() as Promise<SriManifest>;
@@ -82,8 +76,19 @@ const useSriManifest = (environment: string): UseSriManifestResult => {
         const resolvedVersion = manifest.version ?? 'unknown';
         const resolvedSri = scriptEntry.sri;
 
-        // Resolve the CORS probe result alongside the manifest
-        scriptCorsprobe
+        // Probe the CDN for CORS support AFTER the manifest resolves. Creating
+        // this fetch earlier (in parallel with the manifest fetch) meant its
+        // `.then/.catch` handlers were only attached inside the manifest's
+        // resolution callback — so if the shared AbortController fired before
+        // the manifest resolved (e.g. React 18 StrictMode's simulated unmount
+        // in dev, or a real unmount during the fetch window), the probe's
+        // AbortError rejection had no handler and surfaced as an uncaught
+        // promise rejection.
+        fetch(scriptUrl, {
+          method: 'HEAD',
+          mode: 'cors',
+          signal: controller.signal,
+        })
           .then(() => {
             // instnt_v1.js responded to a CORS request — safe to set crossOrigin
             manifestCache.set(environment, {


### PR DESCRIPTION
This is reliably triggered by React 18 `StrictMode` in development, which double-invokes effects (mount → simulated unmount → remount). The simulated unmount calls `controller.abort()` before `manifestFetch` has a chance to resolve, leaving `scriptCorsprobe` orphaned.

## Fix

Move the CORS probe `fetch(...)` **inside** the manifest's resolution callback, so:
- The probe is only issued after the manifest successfully resolves (when its result is actually needed).
- The probe's `.then/.catch` handlers are attached synchronously on creation.
- If the controller aborts before the manifest resolves, the probe is never created — nothing to orphan.

No behavioral change for the success path or the manifest-failure path.

## Repro

Render `<InstntSignupProvider formKey="..." serviceURL="..." />` under React 18 `<StrictMode>` in dev. The red overlay appears on first mount.

## Tests

Added a regression test that renders the hook, unmounts before any fetch resolves, and asserts no `unhandledrejection` event fires. Verified:
- Against the current `master` code → test fails (reproduces the bug)
- With this fix applied → test passes
- Full existing suite (33 tests across 6 files) → all pass

## Context

Found while integrating v2.1.4 in a React 18 / Nx app. Also present in `2.1.5-beta.3`.